### PR TITLE
manifest Update for pygame and vte

### DIFF
--- a/org.sugarlabs.Pippy.json
+++ b/org.sugarlabs.Pippy.json
@@ -129,8 +129,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/vte/0.76/vte-0.76.3.tar.xz",
-                    "sha256": "f678e94c056f377fd0021214adff5450cb172e9a08b160911181ddff7b7d5d60",
+                    "url": "https://download.gnome.org/sources/vte/0.77/vte-0.77.0.tar.xz",
+                    "sha256": "97aa3ebf61231de7f8c60ab350ad0f6c1b232157a25dfcd7893894c28e0868f6",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "vte",

--- a/org.sugarlabs.Pippy.json
+++ b/org.sugarlabs.Pippy.json
@@ -28,8 +28,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/c6/aa/2c0c867d6cff00966cfc2152b25f61599f87e88b239e4dcb8ad5357f0f69/pygame-2.5.2.tar.gz",
-                    "sha256": "c1b89eb5d539e7ac5cf75513125fb5f2f0a2d918b1fd6e981f23bf0ac1b1c24a",
+                    "url": "https://files.pythonhosted.org/packages/72/49/bd2fcbadb6a55bb24284bad4f530189401c99ffc234d51ba54756a776eb2/pygame-2.6.0.tar.gz",
+                    "sha256": "722d33ae676aa8533c1f955eded966411298831346b8d51a77dad22e46ba3e35",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "pygame"


### PR DESCRIPTION
manifest: Bump pygame2 version to 2.6.0
manifest: Bump vte version to 0.77.0